### PR TITLE
fix nomenclature of important services throughout repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # OS-diff
-Openstack / Openshift diff tool
+OpenStack / OpenShift diff tool
 
-This tool collects Openstack/Openshift service configurations,
+This tool collects OpenStack/OpenShift service configurations,
 compares configuration files, makes a diff and creates a report to the user
 in order to provide informations and warnings after a migration from
-Openstack to Openstack on Openshift migration.
+OpenStack to OpenStack on OpenShift migration.
 
 ### Usage
 
 #### Pull configuration step
 
-Before running the Pull command you need to configure the ssh access to your environements (Openstack and OCP).
+Before running the Pull command you need to configure the ssh access to your environements (OpenStack and OCP).
 Edit the ssh.config provided with this project and make sure you can ssh on your hosts with the command:
 
 ```
@@ -169,12 +169,12 @@ Source file path: /tmp/collect_ocp_configs/keystone/etc/keystone/keystone.conf, 
 -max_active_keys=5
 ```
 
-### Openshift Pod config comparison
+### OpenShift Pod config comparison
 
-When you prepare the adoption of your TripleO cloud to your Openshift cluster, you might want to compare and verify if the config describe in your Openshift config desc file has no difference with your Tripleo service config or even, want to verify that after patching the Openshift config, the service is correctly configured.
+When you prepare the adoption of your TripleO cloud to your OpenShift cluster, you might want to compare and verify if the config describe in your OpenShift config desc file has no difference with your Tripleo service config or even, want to verify that after patching the OpenShift config, the service is correctly configured.
 
-The service command allow you to compare Yaml Openshift config patch with Openstack Ini configuration file from your services.
-You can also query Openshift pods to check if the configuration are well set.
+The service command allow you to compare Yaml OpenShift config patch with OpenStack Ini configuration file from your services.
+You can also query OpenShift pods to check if the configuration are well set.
 
 Example:
 
@@ -233,9 +233,9 @@ Source file path: examples/glance/glance.patch, difference with: /etc/glance/gla
 
 ### Add service
 
-If you want to add a new Openstack service to this tool follow those instructions:
+If you want to add a new OpenStack service to this tool follow those instructions:
 
-* Convert your Openshift configmap to a GO struct with:
+* Convert your OpenShift configmap to a GO struct with:
 https://zhwt.github.io/yaml-to-go/
 * Create a <service-name>.go file into pkg/servicecfg/
 * Paste your generated structure and the following code:
@@ -259,7 +259,7 @@ type YourServiceName struct {
   }
 }
 
-func LoadYourServiceNameOpenshiftConfig(configPath string) string {
+func LoadYourServiceNameOpenShiftConfig(configPath string) string {
 	var sb strings.Builder
 	var yourService YourService
 
@@ -279,7 +279,7 @@ func LoadYourServiceNameOpenshiftConfig(configPath string) string {
 }
 ```
 
-* The function `LoadYourServiceNameOpenshiftConfig` is made to extract the configmap Ini parameters for your Openstack service. All the config parameters you want to extract should be declare here.
+* The function `LoadYourServiceNameOpenShiftConfig` is made to extract the configmap Ini parameters for your OpenStack service. All the config parameters you want to extract should be declare here.
 
 
 ### Asciinema demo

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,8 +25,8 @@ import (
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "os-diff",
-	Short: "Tool for pulling and inspecting config files for Openstack services",
-	Long: `Pull and compare Openstack services configuration files from pods
+	Short: "Tool for pulling and inspecting config files for OpenStack services",
+	Long: `Pull and compare OpenStack services configuration files from pods
 or podman containers. For example:
 
 You can pull configuration from a Keystone container and compare

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -33,8 +33,8 @@ var sidebyside bool
 
 var serviceCmd = &cobra.Command{
 	Use:   "service",
-	Short: "Print diff between an Openshift Config spec and an Openstack service config file",
-	Long: `Print diff from an Openshit config spec file and an Openstack sercice config file.
+	Short: "Print diff between an OpenShift Config spec and an OpenStack service config file",
+	Long: `Print diff from an OpenShift config spec file and an OpenStack sercice config file.
 		   For example:
            ./os-diff service --service cinder --ocp examples/cinder/cinder.patch --serviceconfig examples/cinder/cinder.conf
 		   or
@@ -57,11 +57,11 @@ var serviceCmd = &cobra.Command{
 }
 
 func init() {
-	serviceCmd.Flags().StringVarP(&ocp, "ocp", "o", "", "Openshift config spec file path.")
-	serviceCmd.Flags().StringVarP(&config, "config", "c", "", "Openstack service config file path.")
-	serviceCmd.Flags().StringVarP(&service, "service", "s", "", "Openstack service, could be one of: Cinder, Glance...")
+	serviceCmd.Flags().StringVarP(&ocp, "ocp", "o", "", "OpenShift config spec file path.")
+	serviceCmd.Flags().StringVarP(&config, "config", "c", "", "OpenStack service config file path.")
+	serviceCmd.Flags().StringVarP(&service, "service", "s", "", "OpenStack service, could be one of: Cinder, Glance...")
 	serviceCmd.Flags().BoolVar(&frompod, "frompod", false, "Get config file directly from OpenShift service Pod.")
-	serviceCmd.Flags().BoolVar(&frompodman, "frompodman", false, "Get config file directly from Openstack podman container.")
+	serviceCmd.Flags().BoolVar(&frompodman, "frompodman", false, "Get config file directly from OpenStack podman container.")
 	serviceCmd.Flags().BoolVar(&sidebyside, "sidebyside", false, "Compare both: source->dest and dest->source.")
 	serviceCmd.Flags().StringVarP(&podname, "podname", "p", "", "Name of the pod of the service: cinder-api.")
 	rootCmd.AddCommand(serviceCmd)

--- a/examples/cinder/cinder.conf
+++ b/examples/cinder/cinder.conf
@@ -1177,7 +1177,7 @@ osapi_volume_workers=4
 
 # The Infortrend CLI cache. While set True, the RAID status report will use
 # cache stored in the CLI. Never enable this unless the RAID is managed only by
-# Openstack and only by one infortrend cinder-volume backend. Otherwise, CLI
+# OpenStack and only by one infortrend cinder-volume backend. Otherwise, CLI
 # might report out-dated status to cinder and thus there might be some race
 # condition among all backend/CLIs. (boolean value)
 #infortrend_cli_cache = false

--- a/pkg/servicecfg/cinder.go
+++ b/pkg/servicecfg/cinder.go
@@ -60,7 +60,7 @@ type Cinder struct {
 	} `yaml:"spec"`
 }
 
-func LoadCinderOpenshiftConfig(configPath string) string {
+func LoadCinderOpenShiftConfig(configPath string) string {
 
 	// String builder for Cinder Config
 	var sb strings.Builder

--- a/pkg/servicecfg/glance.go
+++ b/pkg/servicecfg/glance.go
@@ -70,7 +70,7 @@ type Glance struct {
 	} `yaml:"spec"`
 }
 
-func LoadGlanceOpenshiftConfig(configPath string) string {
+func LoadGlanceOpenShiftConfig(configPath string) string {
 	var sb strings.Builder
 	// Service structure
 	var service Glance

--- a/pkg/servicecfg/service.go
+++ b/pkg/servicecfg/service.go
@@ -20,12 +20,12 @@ func DiffServiceConfig(service string, ocpConfig string, serviceConfig string, s
 	var servicePatch string
 	// Get ocpConfig
 	if service == "cinder" {
-		servicePatch = LoadCinderOpenshiftConfig(ocpConfig)
+		servicePatch = LoadCinderOpenShiftConfig(ocpConfig)
 	} else if service == "glance" {
-		servicePatch = LoadGlanceOpenshiftConfig(ocpConfig)
+		servicePatch = LoadGlanceOpenShiftConfig(ocpConfig)
 	} else {
 		msg := `Service not supported, please implement it.
-			Follow the instructions to add new Openstack services here:
+			Follow the instructions to add new OpenStack services here:
 			https://github.com/openstack-k8s-operators/os-diff#add-service`
 		panic(msg)
 	}
@@ -55,14 +55,14 @@ func DiffServiceConfigFromPod(service string, ocpConfig string, serviceConfig st
 	// Get ocpConfig
 	if service == "cinder" {
 		podName = "cinder"
-		servicePatch = LoadCinderOpenshiftConfig(ocpConfig)
+		servicePatch = LoadCinderOpenShiftConfig(ocpConfig)
 	} else if service == "glance" {
 		// @todo: should be move a config spec file, users must be describe their env in a file.cfg.
 		podName = "glance-external-api"
-		servicePatch = LoadGlanceOpenshiftConfig(ocpConfig)
+		servicePatch = LoadGlanceOpenShiftConfig(ocpConfig)
 	} else {
 		msg := `Service not supported, please implement it.
-			Follow the instructions to add new Openstack services here:
+			Follow the instructions to add new OpenStack services here:
 			https://github.com/openstack-k8s-operators/os-diff#add-service`
 		panic(msg)
 	}
@@ -83,12 +83,12 @@ func DiffServiceConfigFromPodman(service string, ocpConfig string, serviceConfig
 	var servicePatch string
 	// Get ocpConfig
 	if service == "cinder" {
-		servicePatch = LoadCinderOpenshiftConfig(ocpConfig)
+		servicePatch = LoadCinderOpenShiftConfig(ocpConfig)
 	} else if service == "glance" {
-		servicePatch = LoadGlanceOpenshiftConfig(ocpConfig)
+		servicePatch = LoadGlanceOpenShiftConfig(ocpConfig)
 	} else {
 		msg := `Service not supported, please implement it.
-			Follow the instructions to add new Openstack services here:
+			Follow the instructions to add new OpenStack services here:
 			https://github.com/openstack-k8s-operators/os-diff#add-service`
 		panic(msg)
 	}

--- a/pkg/servicecfg/utils.go
+++ b/pkg/servicecfg/utils.go
@@ -65,7 +65,7 @@ func GetConfigFromPodman(serviceConfigPath string, podmanName string) ([]byte, e
 	return []byte(out), nil
 }
 
-func GenerateOpenshiftConfig(outputConfigPath string, serviceConfigPath string) error {
+func GenerateOpenShiftConfig(outputConfigPath string, serviceConfigPath string) error {
 	return nil
 }
 


### PR DESCRIPTION
This patch fixes instances of "Openshift" and "Openstack" to be correctly capitalized, and fixes one rather embarrassing typo!