### PR TITLE
Rename configFile to configFileName in cmd/generate.go because of var…

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -24,7 +24,7 @@ import (
 
 // represents the generate command
 var serviceName string
-var configFile string
+var configFileName string
 var outputFile string
 var serviceEnable bool
 
@@ -34,7 +34,7 @@ var generateCmd = &cobra.Command{
 	Long: `Config helpers, generate config patch a config file, example:
 	./os-diff gen --service glance --config my-conf.ini --output glance.patch`,
 	Run: func(cmd *cobra.Command, args []string) {
-		err := servicecfg.GenerateConfigPatchFromIni(serviceName, configFile, outputFile, serviceEnable)
+		err := servicecfg.GenerateConfigPatchFromIni(serviceName, configFileName, outputFile, serviceEnable)
 		if err != nil {
 			panic(err)
 		}
@@ -43,7 +43,7 @@ var generateCmd = &cobra.Command{
 
 func init() {
 	generateCmd.Flags().StringVarP(&serviceName, "service", "s", "", "OpenStack service, could be one of: Cinder, Glance...")
-	generateCmd.Flags().StringVarP(&configFile, "config", "c", "", "Configuration file from which you want to generate config patch.")
+	generateCmd.Flags().StringVarP(&configFileName, "config", "c", "", "Configuration file from which you want to generate config patch.")
 	generateCmd.Flags().StringVarP(&outputFile, "output", "o", "", "Output file name for the config patch.")
 	generateCmd.Flags().BoolVar(&serviceEnable, "enable", false, "Enable the service.")
 	rootCmd.AddCommand(generateCmd)


### PR DESCRIPTION
…iable conflicts

When we merged the 3 PRs we got conflig variable in the cobracli, this commit fixing the issue.