### PR TITLE
Fix signs +/- when values are different

### DIFF
--- a/pkg/godiff/utils.go
+++ b/pkg/godiff/utils.go
@@ -223,7 +223,7 @@ func CompareIni(rawdata1 []byte, rawdata2 []byte, origin string, dest string, ve
 					if !sectionFound {
 						sectionFound = true
 						msg = fmt.Sprintf(
-							"[%s]\n+%s=%s\n-%s=%s\n",
+							"[%s]\n-%s=%s\n+%s=%s\n",
 							sec1.Name(),
 							key1.Name(),
 							key1.Value(),
@@ -231,7 +231,7 @@ func CompareIni(rawdata1 []byte, rawdata2 []byte, origin string, dest string, ve
 							key2.Value(),
 						)
 					} else {
-						msg = fmt.Sprintf("+%s=%s\n-%s=%s\n", key1.Name(), key1.Value(), key2.Name(), key2.Value())
+						msg = fmt.Sprintf("-%s=%s\n+%s=%s\n", key1.Name(), key1.Value(), key2.Name(), key2.Value())
 					}
 					if !stringInSlice(msg, report) {
 						diffFound = true


### PR DESCRIPTION
When values are different we want to have
-foo=bar
+foo=bar2

when bar is replaced by bar2

Currently, the sign are this opposite which doesnt make sense.