### PR TITLE
Fix remote diff command and CLI and add doc string

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -93,7 +93,7 @@ Example for directories:
 
 func init() {
 	diffCmd.Flags().StringVarP(&file1Cmd, "file1-cmd", "", "", "Remote command for the file1 configuration file.")
-	diffCmd.Flags().StringVarP(&file1Cmd, "file2-cmd", "", "", "Remote command for the file2 configuration file.")
+	diffCmd.Flags().StringVarP(&file2Cmd, "file2-cmd", "", "", "Remote command for the file2 configuration file.")
 	diffCmd.Flags().BoolVar(&debug, "debug", false, "Enable debug.")
 	diffCmd.Flags().BoolVar(&quiet, "quiet", false, "Do not print difference on the console and use logs report, only for files comparison")
 	diffCmd.Flags().BoolVar(&remote, "remote", false, "Run the diff remotely.")

--- a/pkg/godiff/compare.go
+++ b/pkg/godiff/compare.go
@@ -152,16 +152,16 @@ func CompareFilesFromRemote(origin string, dest string, originRemoteCmd string, 
 	// Get Config
 	originConfigContent, err := GetConfigFromRemote(originRemoteCmd, origin)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	destConfigContent, err := GetConfigFromRemote(destRemoteCmd, dest)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	report, err := CompareIni(originConfigContent, destConfigContent, origin, dest, verbose)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	if report != nil {
 		PrintReport(report)

--- a/pkg/godiff/utils.go
+++ b/pkg/godiff/utils.go
@@ -363,11 +363,9 @@ func CompareRawData(rawdata1 []byte, rawdata2 []byte, origin string, dest string
 }
 
 func GetConfigFromRemote(remoteCmd string, configPath string) ([]byte, error) {
-
-	fullCmd := remoteCmd + " cat" + " " + configPath
-	remoteArray := strings.Split(fullCmd, " ")
-	cmd := exec.Command(remoteArray[0], remoteArray[1:]...)
-	out, err := cmd.CombinedOutput()
+	// Build command:
+	cmd := remoteCmd + " cat" + " " + configPath
+	out, err := exec.Command("bash", "-c", cmd).Output()
 	if err != nil {
 		fmt.Println(string(out))
 		return out, err

--- a/pkg/servicecfg/utils.go
+++ b/pkg/servicecfg/utils.go
@@ -80,7 +80,7 @@ func GenerateOpenShiftConfig(outputConfigPath string, serviceConfigPath string) 
 
 func GetPodFullName(podName string) (string, error) {
 	// Get full pod name
-	cmd := "oc get pod | grep " + podName + " | cut -f 1 -d' '"
+	cmd := "oc get pod | grep " + podName + " | grep -i running | cut -f 1 -d' '"
 	output, err := exec.Command("bash", "-c", cmd).Output()
 	if err != nil {
 		return string(output), err


### PR DESCRIPTION
For the remote diff case, we need to check if the --remote is true before trying to stat file on the file system.