### PR TITLE
Use fully-qualified name

### DIFF
--- a/cmd/cfg-diff.go
+++ b/cmd/cfg-diff.go
@@ -17,7 +17,7 @@
 package cmd
 
 import (
-	"os-diff/pkg/servicecfg"
+	"github.com/openstack-k8s-operators/os-diff/pkg/servicecfg"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/configmap.go
+++ b/cmd/configmap.go
@@ -18,7 +18,7 @@ package cmd
 
 import (
 	"fmt"
-	"os-diff/pkg/servicecfg"
+	"github.com/openstack-k8s-operators/os-diff/pkg/servicecfg"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -19,7 +19,7 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"os-diff/pkg/godiff"
+	"github.com/openstack-k8s-operators/os-diff/pkg/godiff"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -17,7 +17,7 @@
 package cmd
 
 import (
-	"os-diff/pkg/servicecfg"
+	"github.com/openstack-k8s-operators/os-diff/pkg/servicecfg"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -18,8 +18,8 @@ package cmd
 
 import (
 	"fmt"
-	"os-diff/pkg/collectcfg"
-	"os-diff/pkg/common"
+	"github.com/openstack-k8s-operators/os-diff/pkg/collectcfg"
+	"github.com/openstack-k8s-operators/os-diff/pkg/common"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,7 +19,7 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"os-diff/pkg/common"
+	"github.com/openstack-k8s-operators/os-diff/pkg/common"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module os-diff
+module github.com/openstack-k8s-operators/os-diff
 
 go 1.19
 

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@
  */
 package main
 
-import "os-diff/cmd"
+import "github.com/openstack-k8s-operators/os-diff/cmd"
 
 func main() {
 	cmd.Execute()

--- a/pkg/collectcfg/fetch.go
+++ b/pkg/collectcfg/fetch.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os-diff/pkg/common"
+	"github.com/openstack-k8s-operators/os-diff/pkg/common"
 	"os/exec"
 	"path"
 	"strings"

--- a/pkg/servicecfg/service.go
+++ b/pkg/servicecfg/service.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os-diff/pkg/godiff"
+	"github.com/openstack-k8s-operators/os-diff/pkg/godiff"
 	"path/filepath"
 	"strings"
 

--- a/pkg/servicecfg/utils.go
+++ b/pkg/servicecfg/utils.go
@@ -19,7 +19,7 @@ package servicecfg
 import (
 	"fmt"
 	"io/ioutil"
-	"os-diff/pkg/godiff"
+	"github.com/openstack-k8s-operators/os-diff/pkg/godiff"
 	"os/exec"
 	"strings"
 )


### PR DESCRIPTION
By default, when running "go mod init", Go sets the module with fully-qualified name which is a best-practise.