### PR TITLE
Don't retain ovn_match_northd_version from adopted host

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,6 @@ Then you can provide a mapping between in this case the EDPM CRD, and the ovs-vs
             ovn-bridge: edpm_ovn_bridge
             ovn-bridge-mappings: edpm_ovn_bridge_mappings
             ovn-encap-type: edpm_ovn_encap_type
-            ovn-match-northd-version: ovn_match_northd_version
             ovn-monitor-all: ovn_monitor_all
             ovn-ofctrl-wait-before-clear: edpm_ovn_ofctrl_wait_before_clear
             ovn-remote-probe-interval: edpm_ovn_remote_probe_interval
@@ -207,7 +206,6 @@ services:
       ovn-bridge-mappings: edpm_ovn_bridge_mappings
       ovn-bridge: edpm_ovn_bridge
       ovn-encap-type: edpm_ovn_encap_type
-      ovn-match-northd-version: ovn_match_northd_version
       ovn-monitor-all: ovn_monitor_all
       ovn-remote-probe-interval: edpm_ovn_remote_probe_interval
       ovn-ofctrl-wait-before-clear: edpm_ovn_ofctrl_wait_before_clear

--- a/config.yaml
+++ b/config.yaml
@@ -36,7 +36,6 @@ services:
       ovn-bridge-mappings: edpm_ovn_bridge_mappings
       ovn-bridge: edpm_ovn_bridge
       ovn-encap-type: edpm_ovn_encap_type
-      ovn-match-northd-version: ovn_match_northd_version
       ovn-monitor-all: ovn_monitor_all
       ovn-remote-probe-interval: edpm_ovn_remote_probe_interval
       ovn-ofctrl-wait-before-clear: edpm_ovn_ofctrl_wait_before_clear

--- a/pkg/servicecfg/edpm.go
+++ b/pkg/servicecfg/edpm.go
@@ -103,7 +103,6 @@ type OpenStackDataPlaneNodeSet struct {
 					EdpmOvnBridgeMappings                      []string `yaml:"edpm_ovn_bridge_mappings"`
 					EdpmOvnBridge                              string   `yaml:"edpm_ovn_bridge"`
 					EdpmOvnEncapType                           string   `yaml:"edpm_ovn_encap_type"`
-					OvnMatchNorthdVersion                      bool     `yaml:"ovn_match_northd_version"`
 					OvnMonitorAll                              bool     `yaml:"ovn_monitor_all"`
 					EdpmOvnRemoteProbeInterval                 int      `yaml:"edpm_ovn_remote_probe_interval"`
 					EdpmOvnOfctrlWaitBeforeClear               int      `yaml:"edpm_ovn_ofctrl_wait_before_clear"`


### PR DESCRIPTION
There is no good reason to have this setting set to anything but `false`. If set to `true`, this will render OVN controllers broken until northd on control plane is fully upgraded.

Since [1], we guarantee that ovn controllers are always updated before northd.

See more details in [2].

[1] https://github.com/openstack-k8s-operators/openstack-operator/pull/792
[2] https://github.com/openstack-k8s-operators/edpm-ansible/pull/651