### PR TITLE
Specify undercloud as host

### DIFF
--- a/pkg/collectcfg/fetch.go
+++ b/pkg/collectcfg/fetch.go
@@ -220,7 +220,7 @@ func SyncConfigDir(localPath string, remotePath string, sshCmd string, underclou
 		return err
 	}
 	if undercloud != "" {
-		cmd = "rsync -a -e '" + sshCmd + "' :" + remotePath + " " + localPath
+		cmd = "rsync -a -e '" + sshCmd + " " + undercloud + "' :" + remotePath + " " + localPath
 		common.ExecCmd(cmd)
 	} else {
 		hosts := GetListHosts(undercloud)


### PR DESCRIPTION
Without specifying a host rsync command is not assembled correctly and fails. Also it doesn't allow it to run outside of undercloud. This patch sets undercloud as host allowing rsync to work properly

Closes: OSPRH-11928