### PR TITLE
Fix non-constant format string in fmt.Errorf call

### DIFF
--- a/pkg/collectcfg/fetch.go
+++ b/pkg/collectcfg/fetch.go
@@ -252,7 +252,7 @@ func GetListHosts(undercloud string) []string {
 
 func CleanUp(remotePath string, sshCmd string) error {
 	if remotePath == "" || remotePath == "/" {
-		return fmt.Errorf("Clean up Error - Empty or wrong path: " + remotePath + ". Please make sure you provided a correct path.")
+		return fmt.Errorf("Clean up Error - Empty or wrong path: %s. Please make sure you provided a correct path.", remotePath)
 	}
 	if Sudo {
 		sshCmd = sshCmd + " sudo "


### PR DESCRIPTION
## Summary
- Fix `go vet` error: `non-constant format string in call to fmt.Errorf` in `pkg/collectcfg/fetch.go:255`
- Replace string concatenation with `%s` format placeholder
- This fixes the RPM build failure during the `%check` phase ([build log](https://trunk.rdoproject.org/centos9-master/component/podified/32/d5/32d52e70c1dd88df8a625f7b9dd2bab974b03777_740dc2ea/rpmbuild.log))

## Test plan
- [x] `go vet ./pkg/collectcfg/` passes without errors
- [x] RPM build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)